### PR TITLE
Rebuild 0.16.12 for python 3.11

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,6 +11,8 @@ source:
 
 build:
   number: 3
+  # The package ruamel currently is missing on s390x 
+  skip: True  # [s390x]
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:
@@ -26,6 +28,7 @@ requirements:
     - python
     - setuptools
     - ruamel.yaml.clib >=0.1.2
+    - ruamel.ordereddict  # [py27]
 
 test:
   imports:
@@ -41,7 +44,7 @@ about:
   license_family: MIT
   license_file: LICENSE
   summary: "A YAML package for Python. It is a derivative of Kirill Simonov's PyYAML 3.11 which supports YAML1.1"
-  doc_url: https://yaml.readthedocs.io
+  doc_url: http://yaml.readthedocs.io
   dev_url: https://sourceforge.net/projects/ruamel-yaml/
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "ruamel.yaml" %}
-{% set version = "0.17.21" %}
+{% set version = "0.16.12" %}
 
 package:
   name: {{ name|lower }}
@@ -7,13 +7,11 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/ruamel.yaml-{{ version }}.tar.gz
-  sha256: 8b7ce697a2f212752a35c1ac414471dc16c424c9573be4926b56ff3f5d23b7af
+  sha256: 076cc0bc34f1966d920a49f18b52b6ad559fbe656a0748e3535cf7b3f29ebf9e
 
 build:
-
   number: 3
   # The package ruamel currently is missing on s390x 
-  skip: True  # [s390x]
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:
@@ -23,11 +21,10 @@ requirements:
     - python
     - pip
     - ruamel
-    - setuptools
+    - setuptools >=20.6.8
     - wheel
   run:
     - python
-
     - setuptools
     - ruamel.yaml.clib >=0.1.2
     - ruamel.ordereddict  # [py27]
@@ -45,11 +42,8 @@ about:
   license: MIT
   license_family: MIT
   license_file: LICENSE
-  license_url: https://sourceforge.net/p/ruamel-yaml/code/ci/{{ version }}/tree/LICENSE
   summary: "A YAML package for Python. It is a derivative of Kirill Simonov's PyYAML 3.11 which supports YAML1.1"
-  description: "A YAML parser/emitter that supports roundtrip preservation of comments, seq/map flow style, and map key order"
-  doc_url: https://yaml.readthedocs.io
-  doc_source_url: https://sourceforge.net/p/ruamel-yaml/code/ci/{{ version }}/tree/_doc/
+  doc_url: http://yaml.readthedocs.io
   dev_url: https://sourceforge.net/projects/ruamel-yaml/
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   number: 3
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   build:
@@ -42,7 +42,7 @@ about:
   license_family: MIT
   license_file: LICENSE
   summary: "A YAML package for Python. It is a derivative of Kirill Simonov's PyYAML 3.11 which supports YAML1.1"
-  doc_url: http://yaml.readthedocs.io
+  doc_url: https://yaml.readthedocs.io
   dev_url: https://sourceforge.net/projects/ruamel-yaml/
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 076cc0bc34f1966d920a49f18b52b6ad559fbe656a0748e3535cf7b3f29ebf9e
 
 build:
-  number: 3
+  number: 4
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,6 @@ source:
 
 build:
   number: 3
-  # The package ruamel currently is missing on s390x 
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:


### PR DESCRIPTION
`great-expectations` <-- `ruamel.yaml<0.17.18`

Recipe reverted to 0.16.12 with minimal changes:
- Added `--no-build-isolation`
- Incremented build number.
- Removed unnecessary s390x skip.
