### PR TITLE
update to 0.18.6

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/ruamel.yaml.clib-feedstock/pr6/84e897d

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - https://staging.continuum.io/prefect/fs/ruamel.yaml.clib-feedstock/pr6/84e897d

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,6 +14,8 @@ build:
   skip: true  # [py<37]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   script_env:
+    # To prevent setting a long description in the package metadata from the readme.
+    # Using the current readme results in an encoding mismatch on windows.
     - RUAMEL_NO_LONG_DESCRIPTION=1
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "ruamel.yaml" %}
-{% set version = "0.17.21" %}
+{% set version = "0.18.6" %}
 
 package:
   name: {{ name|lower }}
@@ -7,12 +7,12 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/ruamel.yaml-{{ version }}.tar.gz
-  sha256: 8b7ce697a2f212752a35c1ac414471dc16c424c9573be4926b56ff3f5d23b7af
+  sha256: 8b27e6a217e786c6fbe5634d8f3f11bc63e0f80f6a5890f28863d9c45aac311b
 
 build:
   number: 0
-  skip: true  # [py<35]
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  skip: true  # [py<37]
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   build:
@@ -20,14 +20,13 @@ requirements:
   host:
     - python
     - pip
-    - ruamel
     - setuptools
     - wheel
   run:
     - python
     # Even though upstream lists this optional,
     # importing ruamel.yaml fails without the cli
-    - ruamel.yaml.clib >=0.2.6  # [py<311]
+    - ruamel.yaml.clib >=0.2.7  # [py<313]
 
 test:
   imports:
@@ -42,11 +41,9 @@ about:
   license: MIT
   license_family: MIT
   license_file: LICENSE
-  license_url: https://sourceforge.net/p/ruamel-yaml/code/ci/{{ version }}/tree/LICENSE
   summary: "A YAML package for Python. It is a derivative of Kirill Simonov's PyYAML 3.11 which supports YAML1.1"
   description: "A YAML parser/emitter that supports roundtrip preservation of comments, seq/map flow style, and map key order"
   doc_url: https://yaml.readthedocs.io
-  doc_source_url: https://sourceforge.net/p/ruamel-yaml/code/ci/{{ version }}/tree/_doc/
   dev_url: https://sourceforge.net/projects/ruamel-yaml/
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,6 +13,8 @@ build:
   number: 0
   skip: true  # [py<37]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
+  script_env:
+    - RUAMEL_NO_LONG_DESCRIPTION=1
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,8 +26,6 @@ requirements:
     - wheel
   run:
     - python
-    # Even though upstream lists this optional,
-    # importing ruamel.yaml fails without the cli
     - ruamel.yaml.clib >=0.2.7  # [py<313]
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,14 +35,14 @@ test:
     - pip
   commands:
     - pip check
-  downstreams:
-    - conda-auth
-    - conda-index
-    - conda-lock
-    - conda-project
-    - grayskull
-    - oauthenticator
-    - pyspnego
+  # downstreams:
+  #   - conda-index
+  #   - conda-lock
+  #   - conda-project
+  #   - grayskull
+  #   - oauthenticator
+  #   - pyspnego
+  #   - conda-auth
 
 about:
   home: https://sourceforge.net/projects/ruamel-yaml/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,6 +35,14 @@ test:
     - pip
   commands:
     - pip check
+  downstreams:
+    - conda-auth
+    - conda-index
+    - conda-lock
+    - conda-project
+    - grayskull
+    - oauthenticator
+    - pyspnego
 
 about:
   home: https://sourceforge.net/projects/ruamel-yaml/


### PR DESCRIPTION
ruamel.yaml 0.18.6

**Destination channel:** main

### Links

- PKG-5763
- https://inspector.pypi.io/project/ruamel-yaml/0.18.6/packages/29/81/4dfc17eb6ebb1aac314a3eb863c1325b907863a1b8b1382cdffcb6ac0ed9/ruamel.yaml-0.18.6.tar.gz/
- Relevant dependency PRs:
  - https://github.com/AnacondaRecipes/ruamel.yaml.clib-feedstock/pull/6

