### PR TITLE
ruamel.yaml 0.18.10

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - https://staging.continuum.io/prefect/fs/ruamel.yaml.clib-feedstock/pr7/0935049

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "ruamel.yaml" %}
-{% set version = "0.18.6" %}
+{% set version = "0.18.10" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/ruamel.yaml-{{ version }}.tar.gz
-  sha256: 8b27e6a217e786c6fbe5634d8f3f11bc63e0f80f6a5890f28863d9c45aac311b
+  sha256: 20c86ab29ac2153f80a428e1254a8adf686d3383df04490514ca3b79a362db58
 
 build:
   number: 0
@@ -29,6 +29,8 @@ requirements:
   run:
     - python
     - ruamel.yaml.clib >=0.2.7  # [py<313]
+  run_constrained:
+    - ruamel.yaml.jinja2 >=0.2
 
 test:
   imports:
@@ -37,14 +39,21 @@ test:
     - pip
   commands:
     - pip check
-  # downstreams:
-  #   - conda-index
-  #   - conda-lock
-  #   - conda-project
-  #   - grayskull
-  #   - oauthenticator
-  #   - pyspnego
-  #   - conda-auth
+  downstreams:
+    - conda
+    - conda-index
+    - conda-lock
+    - conda-souschef
+    - anaconda-linter
+    - conda-auth
+    - conda-project
+    - grayskull
+    - great-expectations
+    - jupyter_telemetry
+    - oauthenticator
+    - pyspnego
+    - quilt3
+    - strictyaml
 
 about:
   home: https://sourceforge.net/projects/ruamel-yaml/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,7 +43,7 @@ test:
   # can affect or even break them. We should test them before releasing to the main channel.
   downstreams:
     # PASSED:
-    - conda-lock
+    #- conda-lock
     - conda-souschef
     - conda-project
     - grayskull

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,6 +39,14 @@ test:
     - pip
   commands:
     - pip check
+  downstreams:
+    - conda 25.3.1
+    - conda 25.3.0
+    - conda 25.1.1    # [py<313]
+    - conda 24.11.3   # [py<313]
+    - conda 24.9.2    # [py<313]
+    - conda 24.7.1    # [py<313]
+    - conda 23.11.0   # [py<312]
 
 about:
   home: https://sourceforge.net/projects/ruamel-yaml/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,7 @@ requirements:
     - wheel
   run:
     - python
-    - ruamel.yaml.clib >=0.2.7  # [py<313]
+    - ruamel.yaml.clib >=0.2.7
   run_constrained:
     - ruamel.yaml.jinja2 >=0.2
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,48 +39,6 @@ test:
     - pip
   commands:
     - pip check
-  # Keep this list of the downstream packages because new minor versions of ruamel.yaml
-  # can affect or even break them. We should test them before releasing to the main channel.
-  downstreams:
-    # PASSED:
-    #- conda-lock
-    - conda-souschef
-    - conda-project
-    - grayskull
-    - jupyter_telemetry
-    - pyspnego
-
-    # FAILED:
-    #- conda
-
-    # ImportError: cannot import name 'noarch_python_build_age_default' from 'conda_build.config'
-    # Update conda-index to 0.6.0
-    #- conda-index
-
-    # ExplainedDependencyNeedsBuildingError: Unsatisfiable dependencies for platform osx-arm64: {MatchSpec("percy[version='>=0.1.3']")}
-    # Update to 0.1.5 or skip it because v0.1.5 is available only in the distro-tooling channel
-    #- anaconda-linter
-
-    # conda-auth 0.2.1 has requirement ruamel-yaml<0.18, but you have ruamel-yaml 0.18.10.
-    # Fix the upper bound ruamel-yaml<0.18 in the conda-auth's recipe.
-    #- conda-auth
-
-    #  TypeError: Can only get item pairs from a mapping.
-    #- constructor
-
-    # - package ruamel.yaml-0.16.10-py38h1a28f6b_1 requires python >=3.8,<3.9.0a0, but none of the providers can be installed
-    #- great-expectations
-
-    # ModuleNotFoundError: No module named 'requests_mock'
-    #- oauthenticator
-
-    # quilt3 =* * does not exist (perhaps a typo or a missing channel).
-    # Update quilt3 to 6.3.1 (it doesn't require ruamel.yaml though)
-    #- quilt3
-
-    # nothing provides requested strictyaml
-    # Skip it. It's available only on the sfe1ed40 channel
-    #- strictyaml
 
 about:
   home: https://sourceforge.net/projects/ruamel-yaml/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -53,7 +53,9 @@ test:
     # Update to 0.1.5 or skip it because v0.1.5 is available only in the distro-tooling channel
     #- anaconda-linter
 
-    - conda-auth
+    # conda-auth 0.2.1 has requirement ruamel-yaml<0.18, but you have ruamel-yaml 0.18.10.
+    # Fix the upper bound ruamel-yaml<0.18 in the conda-auth's recipe.
+    #- conda-auth
     - conda-project
 
     #  TypeError: Can only get item pairs from a mapping.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,17 +40,35 @@ test:
   commands:
     - pip check
   downstreams:
-    - conda
-    - conda-index
+    #- conda
+
+    # ImportError: cannot import name 'noarch_python_build_age_default' from 'conda_build.config'
+    # Update conda-index to 0.6.0
+    #- conda-index
+
     - conda-lock
     - conda-souschef
-    - anaconda-linter
+
+    # ExplainedDependencyNeedsBuildingError: Unsatisfiable dependencies for platform osx-arm64: {MatchSpec("percy[version='>=0.1.3']")}
+    # Update to 0.1.5 or skip it because v0.1.5 is available only in the distro-tooling channel
+    #- anaconda-linter
+
     - conda-auth
     - conda-project
+
+    #  TypeError: Can only get item pairs from a mapping.
+    #- constructor
+
     - grayskull
-    - great-expectations
+
+    # - package ruamel.yaml-0.16.10-py38h1a28f6b_1 requires python >=3.8,<3.9.0a0, but none of the providers can be installed
+    #- great-expectations
+
     - jupyter_telemetry
-    - oauthenticator
+
+    # ModuleNotFoundError: No module named 'requests_mock'
+    #- oauthenticator
+
     - pyspnego
     - quilt3
     - strictyaml

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,14 +39,6 @@ test:
     - pip
   commands:
     - pip check
-  downstreams:
-    - conda 25.3.1
-    - conda 25.3.0
-    - conda 25.1.1    # [py<313]
-    - conda 24.11.3   # [py<313]
-    - conda 24.9.2    # [py<313]
-    - conda 24.7.1    # [py<313]
-    - conda 23.11.0   # [py<312]
 
 about:
   home: https://sourceforge.net/projects/ruamel-yaml/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,14 +42,20 @@ test:
   # Keep this list of the downstream packages because new minor versions of ruamel.yaml
   # can affect or even break them. We should test them before releasing to the main channel.
   downstreams:
+    # PASSED:
+    - conda-lock
+    - conda-souschef
+    - conda-project
+    - grayskull
+    - jupyter_telemetry
+    - pyspnego
+
+    # FAILED:
     #- conda
 
     # ImportError: cannot import name 'noarch_python_build_age_default' from 'conda_build.config'
     # Update conda-index to 0.6.0
     #- conda-index
-
-    - conda-lock
-    - conda-souschef
 
     # ExplainedDependencyNeedsBuildingError: Unsatisfiable dependencies for platform osx-arm64: {MatchSpec("percy[version='>=0.1.3']")}
     # Update to 0.1.5 or skip it because v0.1.5 is available only in the distro-tooling channel
@@ -58,26 +64,23 @@ test:
     # conda-auth 0.2.1 has requirement ruamel-yaml<0.18, but you have ruamel-yaml 0.18.10.
     # Fix the upper bound ruamel-yaml<0.18 in the conda-auth's recipe.
     #- conda-auth
-    - conda-project
 
     #  TypeError: Can only get item pairs from a mapping.
     #- constructor
 
-    - grayskull
-
     # - package ruamel.yaml-0.16.10-py38h1a28f6b_1 requires python >=3.8,<3.9.0a0, but none of the providers can be installed
     #- great-expectations
-
-    - jupyter_telemetry
 
     # ModuleNotFoundError: No module named 'requests_mock'
     #- oauthenticator
 
-    - pyspnego
     # quilt3 =* * does not exist (perhaps a typo or a missing channel).
     # Update quilt3 to 6.3.1 (it doesn't require ruamel.yaml though)
     #- quilt3
-    - strictyaml
+
+    # nothing provides requested strictyaml
+    # Skip it. It's available only on the sfe1ed40 channel
+    #- strictyaml
 
 about:
   home: https://sourceforge.net/projects/ruamel-yaml/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,6 +39,8 @@ test:
     - pip
   commands:
     - pip check
+  # Keep this list of the downstream packages because new minor versions of ruamel.yaml
+  # can affect or even break them. We should test them before releasing to the main channel.
   downstreams:
     #- conda
 
@@ -72,7 +74,9 @@ test:
     #- oauthenticator
 
     - pyspnego
-    - quilt3
+    # quilt3 =* * does not exist (perhaps a typo or a missing channel).
+    # Update quilt3 to 6.3.1 (it doesn't require ruamel.yaml though)
+    #- quilt3
     - strictyaml
 
 about:


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-7998](https://anaconda.atlassian.net/browse/PKG-7998) 
- https://inspector.pypi.io/project/ruamel-yaml/0.18.10/packages/ea/46/f44d8be06b85bc7c4d8c95d658be2b68f27711f279bf9dd0612a5e4794f5/ruamel.yaml-0.18.10.tar.gz/

### Explanation of changes:

- Add run_constrained with `ruamel.yaml.jinja2 >=0.2`
- Remove `downstreams`

### Notes:

- Updated dependency https://github.com/AnacondaRecipes/ruamel.yaml.clib-feedstock/pull/7

[PKG-7998]: https://anaconda.atlassian.net/browse/PKG-7998?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ